### PR TITLE
Add no-throw-literal

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,6 +66,7 @@ module.exports = {
     "mocha/no-top-level-hooks": [2],
     "mocha/no-identical-title": [2],
     "mocha/no-nested-tests": [2],
+    "no-throw-literal": [2],
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
This guards against `throw 'error message'` which doesn't preserve a stack trace