### PR TITLE
loosen peerdeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mitodl",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "JavaScript style rules for MITODL",
   "main": "index.js",
   "scripts": {
@@ -14,13 +14,13 @@
   "author": "Alice Pote",
   "license": "ISC",
   "peerDependencies": {
-    "babel-eslint": "^7.2.3",
-    "eslint": "^4.2.0",
-    "eslint-config-google": "^0.9.1",
-    "eslint-plugin-babel": "^4.1.1",
-    "eslint-plugin-flowtype": "^2.35.0",
-    "eslint-plugin-mocha": "^4.11.0",
-    "eslint-plugin-react": "^7.1.0",
-    "prettier-eslint-cli": "^4.1.1"
+    "babel-eslint": "10.x",
+    "eslint": "5.x",
+    "eslint-config-google": "0.x",
+    "eslint-plugin-babel": "5.x",
+    "eslint-plugin-flowtype": "3.x",
+    "eslint-plugin-mocha": "5.x",
+    "eslint-plugin-react": "7.x",
+    "prettier-eslint-cli": "4.x"
   }
 }


### PR DESCRIPTION
loosen the peer-dependencies for this package so it will allow installing `@latest` for all of them. I tested this change out on open-discussions and it all seems good. We hadn't updated this in a year or so, so it was about time!