### PR TITLE
get this to work with newer versions of eslint

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,16 @@ module.exports = {
     "mocha/no-identical-title": [2],
     "mocha/no-nested-tests": [2],
     "no-throw-literal": [2],
+    "arrow-parens": [2, "as-needed"],
+    "valid-jsdoc": 0,
+    "require-jsdoc": 0,
+    "spaced-comment": 0,
+    "no-invalid-this": 0,
+    "one-var": [2, {
+      "uninitialized": "always"
+    }],
+    "no-multi-spaces": 0,
+    "prefer-promise-reject-errors": 0,
   },
   "env": {
     "es6": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mitodl",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "JavaScript style rules for MITODL",
   "main": "index.js",
   "scripts": {
@@ -15,12 +15,12 @@
   "license": "ISC",
   "peerDependencies": {
     "babel-eslint": "10.x",
-    "eslint": "5.x",
+    "eslint": "6.x",
     "eslint-config-google": "0.x",
     "eslint-plugin-babel": "5.x",
-    "eslint-plugin-flowtype": "3.x",
-    "eslint-plugin-mocha": "5.x",
+    "eslint-plugin-flowtype": "4.x",
+    "eslint-plugin-mocha": "6.x",
     "eslint-plugin-react": "7.x",
-    "prettier-eslint-cli": "4.x"
+    "prettier-eslint-cli": "5.x"
   }
 }


### PR DESCRIPTION
this basically does two things:

- fixed the peer dependency ranges to support the latest versions of everything
- added things for rules that were changed in the packages we depend on here (the configs we extend, that it). I added these via a trial-and-error process in discussions, so it's possible I missed one, haha.