### PR TITLE
[proposal] remove flow plugins and rules configuration

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,14 +51,6 @@ module.exports = {
     "space-infix-ops": [2],
     "space-before-blocks": [2],
     "space-in-parens": [2],
-    "flow-vars/define-flow-type": [2],
-    "flow-vars/use-flow-type": [2],
-    "flowtype/space-after-type-colon": [0],
-    "flowtype/space-before-type-colon": [2, "never"],
-    "flowtype/generic-spacing": [2, "never"],
-    "flowtype/no-dupe-keys": [2],
-    "flowtype/no-primitive-constructor-types": [2],
-    "flowtype/object-type-delimiter": [2, "comma"],
     "mocha/no-exclusive-tests": [2],
     "mocha/no-skipped-tests": [2],
     "mocha/no-sibling-hooks": [2],
@@ -97,8 +89,6 @@ module.exports = {
   "plugins": [
     "babel",
     "react",
-    "flowtype",
-    "flow-vars",
     "mocha",
     "react-hooks"
   ]


### PR DESCRIPTION
We've been using TypeScript on ocw-studio for a bit now, and in a few other places as well. It's been nice so far, and it's not looking like we're likely to use Flow on projects going forward, although we are still using it on micromasters and open-discussions.

Right now the current config requires installing `eslint-plugin-flow-vars` and `eslint-plugin-flowtype` even if the project is using TypeScript, which is a bit annoying. So I thought, well, we're not going to use Flow on new projects going forward, so we should go ahead and remove these rules.