### PR TITLE
Ab/bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-mitodl",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "JavaScript style rules for MITODL",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
### What are the relevant tickets?
I forgot to bump the version in package.json in https://github.com/mitodl/eslint-config/pull/21. This is needed to publish the package as v2.0.0 in npm