### PR TITLE
Security: Disable yarn postinstall scripts

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -3,3 +3,4 @@ nodeLinker: "node-modules"
 supportedArchitectures:
   os: [linux, darwin]
   cpu: [x64, arm64]
+enableScripts: false


### PR DESCRIPTION
_This PR was generated automatically via a script._

This PR disables yarn's postinstall scripts by setting `enableScripts: false` in `.yarnrc.yml`. It is part of:

- https://github.com/mitodl/hq/issues/8676

## Why this change?

Disabling postinstall scripts improves security by:
- **Preventing malicious code execution**: Stops potentially harmful scripts from running during package installation
- **Supply chain security**: Reduces risk from compromised packages that could execute malicious postinstall scripts
- **Controlled execution**: Allows manual review and execution of necessary scripts only when needed

## What changed?

- Added `enableScripts: false` to `.yarnrc.yml`

## Impact

- Some packages may require manual script execution if they depend on postinstall hooks
- Improved security posture against supply chain attacks
- No functional changes to core application code

This is a security best practice recommended for production applications to prevent potential malicious code execution during package installation.